### PR TITLE
fix: 시세 조회 GET 요청 포맷 수정

### DIFF
--- a/src/main/java/day6/fullbang/controller/ProductController.java
+++ b/src/main/java/day6/fullbang/controller/ProductController.java
@@ -1,11 +1,11 @@
 package day6.fullbang.controller;
 
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import day6.fullbang.domain.PlaceType;
 import day6.fullbang.dto.request.MarketPriceConditionDto;
 import day6.fullbang.dto.response.MarketPriceDto;
 import day6.fullbang.service.MarketPriceService;
@@ -18,8 +18,12 @@ public class ProductController {
     private final MarketPriceService marketPriceService;
 
     @GetMapping("/product/{addressCodeHead}/marketPrice")
-    public MarketPriceDto getMarketPriceByAddressCode(@RequestBody MarketPriceConditionDto marketPriceConditionDto,
+    public MarketPriceDto getMarketPriceByAddressCode(@RequestParam PlaceType placeType, @RequestParam String date,
+        @RequestParam Integer capacity, @RequestParam Boolean parkingAvailability,
         @PathVariable(name = "addressCodeHead") String addressCodeHead) {
+
+        MarketPriceConditionDto marketPriceConditionDto = new MarketPriceConditionDto(placeType, date, capacity,
+            parkingAvailability);
 
         return marketPriceService.getByAddressCode(marketPriceConditionDto, addressCodeHead);
     }

--- a/src/main/java/day6/fullbang/dto/request/MarketPriceConditionDto.java
+++ b/src/main/java/day6/fullbang/dto/request/MarketPriceConditionDto.java
@@ -1,11 +1,13 @@
 package day6.fullbang.dto.request;
 
 import day6.fullbang.domain.PlaceType;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class MarketPriceConditionDto {
 
     private PlaceType placeType;


### PR DESCRIPTION
- request body -> request parameter

## 체크리스트
- [x] 빌드에 성공했나요?

[comment]: <> (- [ ] 테스트를 모두 통과했나요?)
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

## 개요
`GET` 요청의 request body 미지원 이슈로 인해 해당 인자를 request query parameter로 받도록 컨트롤러 메서드를 수정했습니다.

### 코드를 추가한 이유
상기와 같습니다.

## 작업 사항
`controller/ProductController`: request 양식 수정
`dto/request/MarketPriceConditionDto`: 모든 멤버를 인자로 갖는 생성자 추가

## 변경 로직
- controller 요청 수행 방식 외 변경 사항 없음

## 기타
