### PR TITLE
fix: 좌표 범위 내 시세 조회 중복 에러 수정 [DAY6-150]

### DIFF
--- a/src/main/java/day6/fullbang/domain/AddressCode.java
+++ b/src/main/java/day6/fullbang/domain/AddressCode.java
@@ -5,9 +5,7 @@ import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable

--- a/src/main/java/day6/fullbang/domain/AddressCode.java
+++ b/src/main/java/day6/fullbang/domain/AddressCode.java
@@ -1,0 +1,24 @@
+package day6.fullbang.domain;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+public class AddressCode implements Serializable {
+
+    @Column(name = "region_1depth_code")
+    private String region1DepthAddressCode;
+
+    @Column(name = "region_2depth_code")
+    private String region2DepthAddressCode;
+
+    @Column(name = "region_3depth_code")
+    private String region3DepthAddressCode;
+}

--- a/src/main/java/day6/fullbang/domain/AddressInfo.java
+++ b/src/main/java/day6/fullbang/domain/AddressInfo.java
@@ -1,6 +1,7 @@
 package day6.fullbang.domain;
 
 import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -18,10 +19,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class AddressInfo {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "address_info_id")
-    private Long id;
+    @EmbeddedId
+    private AddressCode addressCode;
 
     @Column(name = "region_1depth_name")
     private String region1DepthName;
@@ -29,30 +28,25 @@ public class AddressInfo {
     private String region2DepthName;
     @Column(name = "region_3depth_name")
     private String region3DepthName;
-    @Column(name = "region_1depth_code")
-    private String region1DepthAddressCode;
-    @Column(name = "region_2depth_code")
-    private String region2DepthAddressCode;
-    @Column(name = "region_3depth_code")
-    private String region3DepthAddressCode;
+
     private Double latitude;
     private Double longitude;
 
     public String getAddressCodeHead(int regionDepth) {
 
-        String result = region1DepthAddressCode;
+        String result = addressCode.getRegion1DepthAddressCode();
 
         if (regionDepth == 1) {
             return result;
         }
 
-        result += region2DepthAddressCode;
+        result += addressCode.getRegion2DepthAddressCode();
 
         if (regionDepth == 2) {
             return result;
         }
 
-        result += region3DepthAddressCode;
+        result += addressCode.getRegion3DepthAddressCode();
 
         return result;
     }

--- a/src/main/java/day6/fullbang/domain/AddressInfo.java
+++ b/src/main/java/day6/fullbang/domain/AddressInfo.java
@@ -3,9 +3,6 @@ package day6.fullbang.domain;
 import javax.persistence.Column;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.Table;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/day6/fullbang/dto/addressInfo/AddressInfoDto.java
+++ b/src/main/java/day6/fullbang/dto/addressInfo/AddressInfoDto.java
@@ -1,7 +1,5 @@
 package day6.fullbang.dto.addressInfo;
 
-import javax.persistence.Column;
-
 import day6.fullbang.domain.AddressInfo;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/day6/fullbang/dto/addressInfo/AddressInfoDto.java
+++ b/src/main/java/day6/fullbang/dto/addressInfo/AddressInfoDto.java
@@ -25,9 +25,9 @@ public class AddressInfoDto {
         region1DepthName = addressInfo.getRegion1DepthName();
         region2DepthName = addressInfo.getRegion2DepthName();
         region3DepthName = addressInfo.getRegion3DepthName();
-        region1DepthAddressCode = addressInfo.getRegion1DepthAddressCode();
-        region2DepthAddressCode = addressInfo.getRegion2DepthAddressCode();
-        region3DepthAddressCode = addressInfo.getRegion3DepthAddressCode();
+        region1DepthAddressCode = addressInfo.getAddressCode().getRegion1DepthAddressCode();
+        region2DepthAddressCode = addressInfo.getAddressCode().getRegion2DepthAddressCode();
+        region3DepthAddressCode = addressInfo.getAddressCode().getRegion3DepthAddressCode();
         latitude = addressInfo.getLatitude();
         longitude = addressInfo.getLongitude();
     }

--- a/src/main/java/day6/fullbang/repository/AddressInfoRepository.java
+++ b/src/main/java/day6/fullbang/repository/AddressInfoRepository.java
@@ -31,7 +31,13 @@ public class AddressInfoRepository {
             .setParameter("longitudeStart", longitudeStart)
             .setParameter("longitudeEnd", longitudeEnd).getResultList();
 
-        addressInfos.forEach(addressInfo -> result.add(new AddressInfoDto(addressInfo, regionDepth)));
+        addressInfos.forEach(addressInfo -> {
+            try {
+                result.add(new AddressInfoDto(addressInfo, regionDepth));
+            } catch (NullPointerException e) {
+                return;
+            }
+        });
 
         return result;
     }

--- a/src/main/java/day6/fullbang/repository/AddressInfoRepository.java
+++ b/src/main/java/day6/fullbang/repository/AddressInfoRepository.java
@@ -24,8 +24,8 @@ public class AddressInfoRepository {
 
         List<AddressInfo> addressInfos = em.createQuery(
             "SELECT a FROM AddressInfo a "
-                + "WHERE a.latitude BETWEEN :latitudeStart AND :latitudeEnd "
-                + "AND a.longitude BETWEEN :longitudeStart AND :longitudeEnd", AddressInfo.class)
+                + "WHERE (a.latitude BETWEEN :latitudeStart AND :latitudeEnd) "
+                + "AND (a.longitude BETWEEN :longitudeStart AND :longitudeEnd)", AddressInfo.class)
             .setParameter("latitudeStart", latitudeStart)
             .setParameter("latitudeEnd", latitudeEnd)
             .setParameter("longitudeStart", longitudeStart)

--- a/src/main/java/day6/fullbang/repository/PlaceRepository.java
+++ b/src/main/java/day6/fullbang/repository/PlaceRepository.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Repository;
 import day6.fullbang.domain.Place;
 import day6.fullbang.dto.request.CoordinateRangeDto;
 import day6.fullbang.dto.request.FilterOptionRequestDto;
-
 import lombok.RequiredArgsConstructor;
 
 @Repository

--- a/src/main/java/day6/fullbang/service/AddressInfoService.java
+++ b/src/main/java/day6/fullbang/service/AddressInfoService.java
@@ -18,8 +18,11 @@ public class AddressInfoService {
     public List<AddressInfoDto> getAddressInfoByCoordinateRange(CoordinateRangeDto coordinateRangeDto,
         int regionDepth) {
 
-        return addressInfoRepository.getAddressInfoByCoordinateRange(coordinateRangeDto.getLatitudeStart(),
+        List<AddressInfoDto> addressInfoByCoordinateRange = addressInfoRepository.getAddressInfoByCoordinateRange(
+            coordinateRangeDto.getLatitudeStart(),
             coordinateRangeDto.getLatitudeEnd(), coordinateRangeDto.getLongitudeStart(),
             coordinateRangeDto.getLongitudeEnd(), regionDepth);
+
+        return addressInfoByCoordinateRange;
     }
 }

--- a/src/main/java/day6/fullbang/service/AddressInfos.java
+++ b/src/main/java/day6/fullbang/service/AddressInfos.java
@@ -1,0 +1,36 @@
+package day6.fullbang.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import day6.fullbang.dto.addressInfo.AddressInfoDto;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+public class AddressInfos {
+
+    @Getter // TODO refactor
+    private final List<AddressInfoDto> addressInfoDtos;
+
+    public boolean addressCodeHeadExist(String addressCodeHead) {
+
+        for (AddressInfoDto addressInfoDto : addressInfoDtos) {
+            if (addressInfoDto.getAddressCodeHead().equals(addressCodeHead)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public AddressInfos(List<AddressInfoDto> addressInfoDtos) {
+
+        this.addressInfoDtos = new ArrayList<>();
+
+        addressInfoDtos.forEach(addressInfoDto -> {
+            if (!this.addressCodeHeadExist(addressInfoDto.getAddressCodeHead())) {
+                this.addressInfoDtos.add(addressInfoDto);
+            }
+        });
+    }
+}

--- a/src/main/java/day6/fullbang/service/AddressInfos.java
+++ b/src/main/java/day6/fullbang/service/AddressInfos.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import day6.fullbang.dto.addressInfo.AddressInfoDto;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 public class AddressInfos {
 
@@ -28,7 +27,7 @@ public class AddressInfos {
         this.addressInfoDtos = new ArrayList<>();
 
         addressInfoDtos.forEach(addressInfoDto -> {
-            if (!this.addressCodeHeadExist(addressInfoDto.getAddressCodeHead())) {
+            if (!addressCodeHeadExist(addressInfoDto.getAddressCodeHead())) {
                 this.addressInfoDtos.add(addressInfoDto);
             }
         });

--- a/src/main/java/day6/fullbang/service/MarketPriceService.java
+++ b/src/main/java/day6/fullbang/service/MarketPriceService.java
@@ -44,7 +44,6 @@ public class MarketPriceService {
         addressInfos.getAddressInfoDtos().forEach(
             addressInfo -> {
                 resultList.add(getByAddressCode(marketPriceConditionDto, addressInfo.getAddressCodeHead()));
-                System.out.println(addressInfo.getAddressCodeHead());
             });
 
         return resultList;

--- a/src/main/java/day6/fullbang/service/MarketPriceService.java
+++ b/src/main/java/day6/fullbang/service/MarketPriceService.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
-import day6.fullbang.dto.addressInfo.AddressInfoDto;
 import day6.fullbang.dto.product.PriceInfoDto;
 import day6.fullbang.dto.request.CoordinateRangeDto;
 import day6.fullbang.dto.request.MarketPriceConditionDto;
@@ -37,14 +36,16 @@ public class MarketPriceService {
     public List<MarketPriceDto> getByCoordinateRange(MarketPriceConditionDto marketPriceConditionDto,
         CoordinateRangeDto coordinateRangeDto, int regionDepth) {
 
-        List<AddressInfoDto> addressInfos = addressInfoService.getAddressInfoByCoordinateRange(coordinateRangeDto,
-            regionDepth);
+        AddressInfos addressInfos = new AddressInfos(
+            addressInfoService.getAddressInfoByCoordinateRange(coordinateRangeDto, regionDepth));
 
         List<MarketPriceDto> resultList = new ArrayList<>();
 
-        addressInfos.forEach(
-            addressInfo -> resultList.add(
-                getByAddressCode(marketPriceConditionDto, addressInfo.getAddressCodeHead())));
+        addressInfos.getAddressInfoDtos().forEach(
+            addressInfo -> {
+                resultList.add(getByAddressCode(marketPriceConditionDto, addressInfo.getAddressCodeHead()));
+                System.out.println(addressInfo.getAddressCodeHead());
+            });
 
         return resultList;
     }

--- a/src/main/java/day6/fullbang/service/MarketPriceService.java
+++ b/src/main/java/day6/fullbang/service/MarketPriceService.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import day6.fullbang.dto.addressInfo.AddressInfoDto;
 import day6.fullbang.dto.product.PriceInfoDto;
 import day6.fullbang.dto.request.CoordinateRangeDto;
 import day6.fullbang.dto.request.MarketPriceConditionDto;

--- a/src/main/java/day6/fullbang/service/MarketPriceService.java
+++ b/src/main/java/day6/fullbang/service/MarketPriceService.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
-import day6.fullbang.dto.addressInfo.AddressInfoDto;
 import day6.fullbang.dto.product.PriceInfoDto;
 import day6.fullbang.dto.request.CoordinateRangeDto;
 import day6.fullbang.dto.request.MarketPriceConditionDto;


### PR DESCRIPTION
## 체크리스트
- [x] 빌드에 성공했나요?

[comment]: <> (- [ ] 테스트를 모두 통과했나요?)
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

## 개요
좌표 범위 내 시세 조회 요청에 따른 응답 비즈니스 로직 내 에러를 수정했습니다.

### 코드를 추가한 이유
기존에 구현한 좌표 범위 요청에 따라 시세 리스트를 반환하는 기능의 성능 개선을 위해 중복 쿼리를 수행하지 않도록 수정하는 작업을 진행하였고, 작업 진행 도중 주소 정보 테이블의 ID 칼럼 중복 이슈로 인해 쿼리 결과가 중복되는 에러를 발견해 수정하였습니다.

## 작업 사항
`domain/addressInfo.java` & `domain/addressCode.java` :  주소 정보 내 `addressCode`를 `Embedded ID`로 리팩터링했습니다.

`domain/addressInfos` : 기존 `addressInfos`를 `일급 컬렉션`으로 리팩터링하여 관련 로직을 클래스 내에서 수행하도록 수정했으며, 생성자 내 동일한 region depth 수준의 중복 주소 정보를 처리하는 로직을 구현했습니다.


## 변경 로직
ProductRepository에서 반환한 주소 정보 리스트를 전부 쿼리를 수행하는 로직에서 동일 region depth 수준 내 중복 주소 정보에 대한 중복 쿼리 수행 방지 로직이 추가되었습니다.

## 기타
