### PR TITLE
fix: 시세 정보 내 주소 정보 추가

### DIFF
--- a/src/main/java/day6/fullbang/dto/response/MarketPriceDto.java
+++ b/src/main/java/day6/fullbang/dto/response/MarketPriceDto.java
@@ -1,5 +1,6 @@
 package day6.fullbang.dto.response;
 
+import day6.fullbang.dto.addressInfo.AddressInfoDto;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -10,5 +11,5 @@ public class MarketPriceDto {
     private final Double mean;
     private final Double minMeanOfRange;
     private final Double maxMeanOfRange;
-
+    private final AddressInfoDto addressInfoDto;
 }

--- a/src/main/java/day6/fullbang/repository/AddressInfoRepository.java
+++ b/src/main/java/day6/fullbang/repository/AddressInfoRepository.java
@@ -48,16 +48,16 @@ public class AddressInfoRepository {
         int regionDepth = 1;
 
         if (addressCodeHead.length() >= 2) {
-            queryString += " WHERE (a.region_1depth_code = ";
+            queryString += " WHERE a.region_1depth_code = ";
             queryString += addressCodeHead.substring(0, 2);
         }
         if (addressCodeHead.length() >= 5) {
-            queryString += " AND (a.region_2depth_code = ";
+            queryString += " AND a.region_2depth_code = ";
             queryString += addressCodeHead.substring(2, 5);
             regionDepth++;
         }
         if (addressCodeHead.length() >= 8) {
-            queryString += " AND (a.region_3depth_code = ";
+            queryString += " AND a.region_3depth_code = ";
             queryString += addressCodeHead.substring(5, 8);
             regionDepth++;
         }

--- a/src/main/java/day6/fullbang/repository/AddressInfoRepository.java
+++ b/src/main/java/day6/fullbang/repository/AddressInfoRepository.java
@@ -62,7 +62,7 @@ public class AddressInfoRepository {
             regionDepth++;
         }
 
-        AddressInfo addressInfo = (AddressInfo)em.createQuery(queryString, AddressInfo.class);
+        AddressInfo addressInfo = em.createQuery(queryString, AddressInfo.class).getResultList().get(0);
 
         return new AddressInfoDto(addressInfo, regionDepth);
     }

--- a/src/main/java/day6/fullbang/repository/AddressInfoRepository.java
+++ b/src/main/java/day6/fullbang/repository/AddressInfoRepository.java
@@ -48,16 +48,16 @@ public class AddressInfoRepository {
         int regionDepth = 1;
 
         if (addressCodeHead.length() >= 2) {
-            queryString += " WHERE a.region_1depth_code = ";
+            queryString += " WHERE a.addressCode.region1DepthAddressCode = ";
             queryString += addressCodeHead.substring(0, 2);
         }
         if (addressCodeHead.length() >= 5) {
-            queryString += " AND a.region_2depth_code = ";
+            queryString += " AND a.addressCode.region2DepthAddressCode = ";
             queryString += addressCodeHead.substring(2, 5);
             regionDepth++;
         }
         if (addressCodeHead.length() >= 8) {
-            queryString += " AND a.region_3depth_code = ";
+            queryString += " AND a.addressCode.region3DepthAddressCode = ";
             queryString += addressCodeHead.substring(5, 8);
             regionDepth++;
         }

--- a/src/main/java/day6/fullbang/repository/AddressInfoRepository.java
+++ b/src/main/java/day6/fullbang/repository/AddressInfoRepository.java
@@ -41,4 +41,29 @@ public class AddressInfoRepository {
 
         return result;
     }
+
+    public AddressInfoDto getByAddressCode(String addressCodeHead) {
+
+        String queryString = "SELECT a FROM AddressInfo a";
+        int regionDepth = 1;
+
+        if (addressCodeHead.length() >= 2) {
+            queryString += " WHERE (a.region_1depth_code = ";
+            queryString += addressCodeHead.substring(0, 2);
+        }
+        if (addressCodeHead.length() >= 5) {
+            queryString += " AND (a.region_2depth_code = ";
+            queryString += addressCodeHead.substring(2, 5);
+            regionDepth++;
+        }
+        if (addressCodeHead.length() >= 8) {
+            queryString += " AND (a.region_3depth_code = ";
+            queryString += addressCodeHead.substring(5, 8);
+            regionDepth++;
+        }
+
+        AddressInfo addressInfo = (AddressInfo)em.createQuery(queryString, AddressInfo.class);
+
+        return new AddressInfoDto(addressInfo, regionDepth);
+    }
 }

--- a/src/main/java/day6/fullbang/service/AddressInfoService.java
+++ b/src/main/java/day6/fullbang/service/AddressInfoService.java
@@ -25,4 +25,8 @@ public class AddressInfoService {
 
         return addressInfoByCoordinateRange;
     }
+
+    public AddressInfoDto getByAddressCode(String addressCodeHead) {
+        return addressInfoRepository.getByAddressCode(addressCodeHead);
+    }
 }

--- a/src/main/java/day6/fullbang/service/MarketPriceService.java
+++ b/src/main/java/day6/fullbang/service/MarketPriceService.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import day6.fullbang.dto.addressInfo.AddressInfoDto;
 import day6.fullbang.dto.product.PriceInfoDto;
 import day6.fullbang.dto.request.CoordinateRangeDto;
 import day6.fullbang.dto.request.MarketPriceConditionDto;
@@ -30,7 +31,10 @@ public class MarketPriceService {
         Double mean = MarketPriceCalculator.getMean(prices);
         Double confidenceIntervalOffset = MarketPriceCalculator.getConfidenceIntervalOffset(prices);
 
-        return new MarketPriceDto(mean, mean - confidenceIntervalOffset, mean + confidenceIntervalOffset);
+        AddressInfoDto addressInfoDto = addressInfoService.getByAddressCode(addressCodeHead);
+
+        return new MarketPriceDto(mean, mean - confidenceIntervalOffset, mean + confidenceIntervalOffset,
+            addressInfoDto);
     }
 
     public List<MarketPriceDto> getByCoordinateRange(MarketPriceConditionDto marketPriceConditionDto,


### PR DESCRIPTION
## 체크리스트
- [x] 빌드에 성공했나요?

[comment]: <> (- [ ] 테스트를 모두 통과했나요?)
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

## 개요
기존 시세 정보 내 주소 정보가 없음으로 인한 클라이언트 프로그램 문제를 해결하기 위해 코드 수정 작업을 진행했습니다.

### 코드를 추가한 이유
상기 내용과 같습니다.

## 작업 사항
`AddressInfoDto`: 멤버 변수 내 주소 정보 DTO 추가

`AddressInfoRepository`: 주소코드 기반 주소 정보 탐색 기능 구현

`AddressInfoService`: 주소코드 기반 주소 정보 반환

`MarketPriceService`: 시세 정보 내 주소 정보 추가 로직 구현

## 변경 로직

## 기타
