### PR TITLE
feat: 특정 지역 내 숙박업종별 시세 정보 반환 기능 구현

### DIFF
--- a/src/main/java/day6/fullbang/controller/ProductController.java
+++ b/src/main/java/day6/fullbang/controller/ProductController.java
@@ -20,15 +20,22 @@ public class ProductController {
 
     private final MarketPriceService marketPriceService;
 
-    @GetMapping("/product/{addressCodeHead}/marketPrice")
-    public MarketPriceDto getMarketPriceByAddressCode(@RequestParam PlaceType placeType, @RequestParam String date,
-        @RequestParam Integer capacity, @RequestParam Boolean parkingAvailability,
+    @GetMapping("/product/{addressCodeHead}/marketPrice/{placeType}")
+    public MarketPriceDto getMarketPriceByAddressCode(@PathVariable(name = "placeType") PlaceType placeType,
+        @RequestParam String date, @RequestParam Integer capacity, @RequestParam Boolean parkingAvailability,
         @PathVariable(name = "addressCodeHead") String addressCodeHead) {
 
         MarketPriceConditionDto marketPriceConditionDto = new MarketPriceConditionDto(placeType, date, capacity,
             parkingAvailability);
 
         return marketPriceService.getByAddressCode(marketPriceConditionDto, addressCodeHead);
+    }
+
+    @GetMapping("/product/{addressCodeHead}/marketPrice")
+    public List<MarketPriceDto> getAllMarketPriceByAddressCode(@RequestParam String date, @RequestParam Integer capacity,
+        @RequestParam Boolean parkingAvailability, @PathVariable(name = "addressCodeHead") String addressCodeHead) {
+
+        // TODO implement return market price dto list
     }
 
     @GetMapping("/product/inRange/marketPrice/{regionDepth}")

--- a/src/main/java/day6/fullbang/controller/ProductController.java
+++ b/src/main/java/day6/fullbang/controller/ProductController.java
@@ -1,5 +1,7 @@
 package day6.fullbang.controller;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,10 +34,19 @@ public class ProductController {
     }
 
     @GetMapping("/product/{addressCodeHead}/marketPrice")
-    public List<MarketPriceDto> getAllMarketPriceByAddressCode(@RequestParam String date, @RequestParam Integer capacity,
+    public List<MarketPriceDto> getAllMarketPriceByAddressCode(@RequestParam String date,
+        @RequestParam Integer capacity,
         @RequestParam Boolean parkingAvailability, @PathVariable(name = "addressCodeHead") String addressCodeHead) {
 
-        // TODO implement return market price dto list
+        List<MarketPriceDto> result = new ArrayList<>();
+
+        Arrays.asList(PlaceType.values()).forEach(placeType -> {
+            MarketPriceConditionDto marketPriceConditionDto = new MarketPriceConditionDto(placeType, date, capacity,
+                parkingAvailability);
+            result.add(marketPriceService.getByAddressCode(marketPriceConditionDto, addressCodeHead));
+        });
+
+        return result;
     }
 
     @GetMapping("/product/inRange/marketPrice/{regionDepth}")

--- a/src/main/java/day6/fullbang/dto/response/MarketPriceDto.java
+++ b/src/main/java/day6/fullbang/dto/response/MarketPriceDto.java
@@ -1,5 +1,6 @@
 package day6.fullbang.dto.response;
 
+import day6.fullbang.domain.PlaceType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -10,5 +11,6 @@ public class MarketPriceDto {
     private final Double mean;
     private final Double minMeanOfRange;
     private final Double maxMeanOfRange;
+    private final PlaceType placeType;
 
 }

--- a/src/main/java/day6/fullbang/service/MarketPriceService.java
+++ b/src/main/java/day6/fullbang/service/MarketPriceService.java
@@ -30,7 +30,8 @@ public class MarketPriceService {
         Double mean = MarketPriceCalculator.getMean(prices);
         Double confidenceIntervalOffset = MarketPriceCalculator.getConfidenceIntervalOffset(prices);
 
-        return new MarketPriceDto(mean, mean - confidenceIntervalOffset, mean + confidenceIntervalOffset);
+        return new MarketPriceDto(mean, mean - confidenceIntervalOffset, mean + confidenceIntervalOffset,
+            marketPriceConditionDto.getPlaceType());
     }
 
     public List<MarketPriceDto> getByCoordinateRange(MarketPriceConditionDto marketPriceConditionDto,


### PR DESCRIPTION
## 체크리스트
- [x] 빌드에 성공했나요?

[comment]: <> (- [ ] 테스트를 모두 통과했나요?)
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

## 개요
클라이언트 개발 편의성을 위해, 한 번의 요청으로 특정 지역 내 모든 숙박업체 업종별 시세 정보 리스트를 응답으로 보내 주는 기능을 구현했습니다.

### 코드를 추가한 이유
상기한 바와 같습니다.

## 작업 사항
`ProductController`: 숙박 상품 단일/업종별 요청/응답 처리 분리

`MarketPriceDto`: placeType 멤버 추가

`MarketPriceService`: `MarketPriceDto` 내 placeType을 저장하는 코드 구현

## 변경 로직
`ProductController` 내 기존 요청에 대한 응답이 변경됨

## 기타
