### PR TITLE
fix: 시세 정보 조회 시 3depth 주소 정보까지 표시되는 에러 수정 [DAY6-174]

### DIFF
--- a/src/main/java/day6/fullbang/domain/AddressInfo.java
+++ b/src/main/java/day6/fullbang/domain/AddressInfo.java
@@ -26,6 +26,8 @@ public class AddressInfo {
     @Column(name = "region_3depth_name")
     private String region3DepthName;
 
+    private Integer regionDepth;
+
     private Double latitude;
     private Double longitude;
 

--- a/src/main/java/day6/fullbang/dto/addressInfo/AddressInfoDto.java
+++ b/src/main/java/day6/fullbang/dto/addressInfo/AddressInfoDto.java
@@ -20,13 +20,26 @@ public class AddressInfoDto {
 
     public AddressInfoDto(AddressInfo addressInfo, int regionDepth) {
         addressCodeHead = addressInfo.getAddressCodeHead(regionDepth);
-        region1DepthName = addressInfo.getRegion1DepthName();
-        region2DepthName = addressInfo.getRegion2DepthName();
-        region3DepthName = addressInfo.getRegion3DepthName();
-        region1DepthAddressCode = addressInfo.getAddressCode().getRegion1DepthAddressCode();
-        region2DepthAddressCode = addressInfo.getAddressCode().getRegion2DepthAddressCode();
-        region3DepthAddressCode = addressInfo.getAddressCode().getRegion3DepthAddressCode();
         latitude = addressInfo.getLatitude();
         longitude = addressInfo.getLongitude();
+
+        region1DepthName = addressInfo.getRegion1DepthName();
+        region1DepthAddressCode = addressInfo.getAddressCode().getRegion1DepthAddressCode();
+
+        if (addressInfo.getAddressCode().getRegion2DepthAddressCode() != null) {
+            region2DepthName = addressInfo.getRegion2DepthName();
+            region2DepthAddressCode = addressInfo.getAddressCode().getRegion2DepthAddressCode();
+        } else {
+            region2DepthName = "";
+            region2DepthAddressCode = "";
+        }
+
+        if (addressInfo.getAddressCode().getRegion3DepthAddressCode() != null) {
+            region3DepthName = addressInfo.getRegion3DepthName();
+            region3DepthAddressCode = addressInfo.getAddressCode().getRegion3DepthAddressCode();
+        } else {
+            region3DepthName = "";
+            region3DepthAddressCode = "";
+        }
     }
 }

--- a/src/main/java/day6/fullbang/repository/AddressInfoRepository.java
+++ b/src/main/java/day6/fullbang/repository/AddressInfoRepository.java
@@ -24,8 +24,11 @@ public class AddressInfoRepository {
 
         List<AddressInfo> addressInfos = em.createQuery(
             "SELECT a FROM AddressInfo a "
-                + "WHERE (a.latitude BETWEEN :latitudeStart AND :latitudeEnd) "
-                + "AND (a.longitude BETWEEN :longitudeStart AND :longitudeEnd)", AddressInfo.class)
+                + "WHERE a.regionDepth = :regionDepth "
+                + "AND (a.latitude BETWEEN :latitudeStart AND :latitudeEnd) "
+                + "AND (a.longitude BETWEEN :longitudeStart AND :longitudeEnd)",
+            AddressInfo.class)
+            .setParameter("regionDepth", regionDepth)
             .setParameter("latitudeStart", latitudeStart)
             .setParameter("latitudeEnd", latitudeEnd)
             .setParameter("longitudeStart", longitudeStart)


### PR DESCRIPTION
## 체크리스트
- [x] 빌드에 성공했나요?

[comment]: <> (- [ ] 테스트를 모두 통과했나요?)
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

## 개요 
1depth, 2depth 지역 기준 시세 조회 요청 시 주소 정보가 3depth 기준으로 표시되는 문제가 발견되었고, 수정하였습니다.

### 코드를 추가한 이유
상기 내용과 같습니다.

## 작업 사항
`AddressInfo` : regionDepth 멤버 변수 추가

`AddressInfoRepository` : 쿼리스트링 내 regionDepth 조건절 추가

`AddressInfoDto` : 생성자 로직 변경

## 변경 로직

## 기타
